### PR TITLE
Use proper MIT license

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,11 +1,7 @@
-Copyright (C) 2015-2024 Ulf Hermjakob, USC Information Sciences Institute
+Copyright (C) 2015–present Ulf Hermjakob, USC Information Sciences Institute
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 
 The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
 
-Any publication of projects using uroman shall acknowledge its use: "This project uses the universal romanizer software 'uroman' written by Ulf Hermjakob, USC Information Sciences Institute (2015-2020)".
-Bibliography: Ulf Hermjakob, Jonathan May, and Kevin Knight. 2018. Out-of-the-box universal romanization tool uroman. In Proceedings of the 56th Annual Meeting of Association for Computational Linguistics, Demo Track.
-
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-

--- a/README.md
+++ b/README.md
@@ -290,3 +290,8 @@ New features in version 0.3
 
 ### Acknowledgments
 Earlier versions of this tool were based upon work supported in part by the Office of the Director of National Intelligence (ODNI), Intelligence Advanced Research Projects Activity (IARPA), via contract # FA8650-17-C-9116, and by research sponsored by Air Force Research Laboratory (AFRL) under agreement number FA8750-19-1-1000. The views and conclusions contained herein are those of the authors and should not be interpreted as necessarily representing the official policies, either expressed or implied, of ODNI, IARPA, Air Force Laboratory, DARPA, or the U.S. Government. The U.S. Government is authorized to reproduce and distribute reprints for governmental purposes notwithstanding any copyright annotation therein.
+
+### Citation of this Work
+Any academic work using uroman shall:
+* Cite the following paper: "Ulf Hermjakob, Jonathan May, and Kevin Knight. 2018. Out-of-the-box universal romanization tool uroman. In Proceedings of the 56th Annual Meeting of Association for Computational Linguistics, Demo Track."
+* Acknowledge its use in any distributed code, e.g. in the README: "This project uses the universal romanizer software 'uroman' written by Ulf Hermjakob, USC Information Sciences Institute."


### PR DESCRIPTION
This project has a modified form of the MIT license which makes it a PITA to use at companies. Even though it would be basically fine to use, any project which does not have a FOSS license following the *exact wording* of the license needs a customized legal review (i.e. you have to pay lawyers.)

Specifically this language problematic:

```
Any publication of projects using uroman shall acknowledge its use: "This project uses the universal romanizer software 'uroman' written by Ulf Hermjakob, USC Information Sciences Institute (2015-2020)".
Bibliography: Ulf Hermjakob, Jonathan May, and Kevin Knight. 2018. Out-of-the-box universal romanization tool uroman. In Proceedings of the 56th Annual Meeting of Association for Computational Linguistics, Demo Track.
```

The clear intent of this language is to ensure the work (uroman) is cited in academic papers. It's better to move this requirement to the README instead.

Moving this wording to the README does not materially change the spirit of the license, nor does it impose any extra burden on users, so I think it's fine for the project maintainer to unilaterally accept it.