### PR TITLE
Lower requirement to Python 3.8

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ version = "1.3.1.1"
 dependencies = [
   "regex>=2024.5.15",
 ]
-requires-python = ">=3.10"
+requires-python = ">=3.8"
 authors = [
   {name = "Ulf Hermjakob", email = "ulf@isi.edu"},
 ]

--- a/uroman.ipynb
+++ b/uroman.ipynb
@@ -11,7 +11,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 2,
    "id": "32ebed06",
    "metadata": {},
    "outputs": [],
@@ -26,10 +26,21 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "id": "ee63bead",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Νεπάλ Nepal\n",
+      "नेपाल nepaal\n",
+      "نیپال nipal\n",
+      "三万一 31000\n"
+     ]
+    }
+   ],
    "source": [
     "# Romanizing strings from different scripts\n",
     "\n",
@@ -39,10 +50,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
    "id": "2e3444fd",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Игорь rus Igor\n",
+      "Игорь ukr Yhor\n",
+      "Игорь None Igor\n"
+     ]
+    }
+   ],
    "source": [
     "# Romanizing a string using different language codes\n",
     "\n",
@@ -53,10 +74,32 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 5,
    "id": "a47a1c3a",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Input string:\n",
+      "ایران\n",
+      "\n",
+      "Output format: str\n",
+      "iran\n",
+      "\n",
+      "Output format: edges\n",
+      "[[0, 2, \"i\", \"rom\"][2, 3, \"r\", \"rom\"][3, 4, \"a\", \"rom\"][4, 5, \"n\", \"rom\"]]\n",
+      "\n",
+      "Output format: alts\n",
+      "[[0, 2, \"i\", \"rom\"][0, 2, \"ai\", \"rom-alt\"][2, 3, \"r\", \"rom\"][3, 4, \"a\", \"rom\"][4, 5, \"n\", \"rom\"]]\n",
+      "\n",
+      "Output format: lattice\n",
+      "[[0, 2, \"i\", \"rom\"][0, 2, \"ai\", \"rom-alt\"][0, 1, \"a\", \"rom\"][1, 2, \"i\", \"rom\"][1, 2, \"y\", \"rom-alt\"][2, 3, \"r\", \"rom\"][3, 4, \"a\", \"rom\"][4, 5, \"n\", \"rom\"]]\n",
+      "\n"
+     ]
+    }
+   ],
    "source": [
     "# Romanizing a string in different output formats (string, JSONL)\n",
     "\n",
@@ -86,7 +129,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 7,
    "id": "b47a308c",
    "metadata": {
     "scrolled": true
@@ -136,7 +179,7 @@
     "# A file with text from different scripts and languages (marked by line-initial ::lcode <lcode>)\n",
     "# File location: https://github.com/isi-nlp/uroman/blob/master/uroman/mini-test/multi-script.txt\n",
     "\n",
-    "input_filename  = 'multi-script.txt'\n",
+    "input_filename  = 'test/multi-script.txt'\n",
     "\n",
     "with open(input_filename) as f:\n",
     "    print(f.read())"
@@ -144,7 +187,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 8,
    "id": "f4ebe325",
    "metadata": {},
    "outputs": [
@@ -192,7 +235,7 @@
     "# Romanization of a file with text from different scripts and languages\n",
     "# How many US states can you identify in the romanized Hindi (::lcode hin) sentence below?\n",
     "\n",
-    "output_filename = 'multi-script.uroman.txt'\n",
+    "output_filename = 'test/multi-script.uroman.txt'\n",
     "\n",
     "uroman.romanize_file(input_filename=input_filename, output_filename=output_filename)\n",
     "\n",
@@ -203,7 +246,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": ".env",
    "language": "python",
    "name": "python3"
   },
@@ -217,7 +260,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.5"
+   "version": "3.8.10"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
In our production environment, we use Python 3.8, and this library would really help us in our work. We can’t easily switch to a newer Python version.

Let me know if you have Python 3.9+ behavior apart from union type notations.



### Changes done:
- removed Python 3.10 style of union types
- removed parenthesized context managers specific to Python 3.10